### PR TITLE
fix: prevent FileExistsError for creating snapshot failures directory when tests run in parallel

### DIFF
--- a/pytest_playwright_visual_snapshot/plugin.py
+++ b/pytest_playwright_visual_snapshot/plugin.py
@@ -127,7 +127,7 @@ def cleanup_snapshot_failures(pytestconfig: Config):
         shutil.rmtree(SnapshotPaths.failures_path)
 
     # Create the directory to ensure it exists
-    SnapshotPaths.failures_path.mkdir(parents=True)
+    SnapshotPaths.failures_path.mkdir(parents=True, exist_ok=True)
 
     logger.debug(f"Snapshot failures path: {SnapshotPaths.failures_path.resolve()}")
     logger.debug(f"Snapshots path: {SnapshotPaths.snapshots_path.resolve()}")


### PR DESCRIPTION
The plugin previously used Path.mkdir(parents=True) without exist_ok=True, which caused FileExistsError when running tests in parallel with pytest-xdist.

This change adds exist_ok=True to ensure directory creation is safe even if it already exists, avoiding race conditions during parallel test execution.

Fixes an issue observed in CI environments with concurrent test runs.