### PR TITLE
Fix race condition when running tests in parallel

### DIFF
--- a/pytest_playwright_visual_snapshot/plugin.py
+++ b/pytest_playwright_visual_snapshot/plugin.py
@@ -123,6 +123,7 @@ def cleanup_snapshot_failures(pytestconfig: Config):
     )
 
     # Clean up the entire failures directory at session start so past failures don't clutter the result
+    # ignore_errors=True to gracefully fail in the case of multiple pytest processes (xdist)
     shutil.rmtree(SnapshotPaths.failures_path, ignore_errors=True)
 
     # Create the directory to ensure it exists


### PR DESCRIPTION
When running the tests with pytest-xdists, multiple workers see that the directory exists, then try to delete it at the same time, leading to FileNotFoundErrors.