### PR TITLE
Rename option `playwright_kwargs` -> `playwright_visual_screenshot_kwargs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ When enabled, snapshots with different dimensions will still generate the `actua
 
 ### Customizing Screenshot Arguments
 
-You can pass a dictionary of extra keyword arguments to Playwright's `screenshot` method via `playwright_kwargs`. This allows you to use any Playwright-supported screenshot option (like `full_page`, `clip`, `quality`, etc.).
+You can pass a dictionary of extra keyword arguments to Playwright's `screenshot` method via `playwright_visual_screenshot_kwargs`. This allows you to use any Playwright-supported screenshot option (like `full_page`, `clip`, `quality`, etc.).
 
 ```python
 def pytest_configure(config: Config):
-    config.option.playwright_kwargs = {
+    config.option.playwright_visual_screenshot_kwargs = {
         "full_page": True,
         "clip": {"x": 0, "y": 0, "width": 800, "height": 600}
     }

--- a/pytest_playwright_visual_snapshot/plugin.py
+++ b/pytest_playwright_visual_snapshot/plugin.py
@@ -96,7 +96,7 @@ def pytest_addoption(parser: Parser) -> None:
 
     set_pytest_option(
         NAMESPACE,
-        "playwright_kwargs",
+        "playwright_visual_screenshot_kwargs",
         default={},
         help="Dictionary of kwargs to pass to Playwright's screenshot method",
         available=None,  # Runtime only
@@ -267,11 +267,11 @@ class AssertSnapshot:
             )
             or []
         )
-        self._playwright_kwargs = (
+        self._screenshot_kwargs = (
             get_pytest_option(
                 NAMESPACE,
                 pytestconfig,
-                "playwright_kwargs",
+                "playwright_visual_screenshot_kwargs",
                 type_hint=dict,
             )
             or {}
@@ -357,7 +357,7 @@ class AssertSnapshot:
                 "scale": "css",
                 "type": "png",
                 "mask": masks,
-                **self._playwright_kwargs,
+                **self._screenshot_kwargs,
             }
 
             img = img_or_page.screenshot(**screenshot_kwargs)

--- a/pytest_playwright_visual_snapshot/plugin.py
+++ b/pytest_playwright_visual_snapshot/plugin.py
@@ -105,7 +105,7 @@ def pytest_addoption(parser: Parser) -> None:
 
     set_pytest_option(
         NAMESPACE,
-        "update_snapshots",
+        "playwright_visual_update_snapshots",
         default=False,
         help="Update snapshots",
         available=None,  # Handled manually below
@@ -120,7 +120,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--update-snapshots",
         action="store_true",
         default=None,
-        dest="update_snapshots",
+        dest="playwright_visual_update_snapshots",
         help="Update snapshots.",
     )
 
@@ -280,7 +280,7 @@ class AssertSnapshot:
             get_pytest_option(
                 NAMESPACE,
                 pytestconfig,
-                "update_snapshots",
+                "playwright_visual_update_snapshots",
                 type_hint=bool,
             )
         )

--- a/tests/test_screenshot_kwargs.py
+++ b/tests/test_screenshot_kwargs.py
@@ -7,11 +7,11 @@ from tests.conftest import (
 )
 
 
-def test_playwright_kwargs_clip(testdir: pytest.Testdir) -> None:
+def test_screenshot_kwargs_clip(testdir: pytest.Testdir) -> None:
     testdir.makeconftest(
         """
         def pytest_configure(config):
-            config.option.playwright_kwargs = {
+            config.option.playwright_visual_screenshot_kwargs = {
                 "clip": {"x": 0, "y": 0, "width": 50, "height": 50}
             }
         """


### PR DESCRIPTION
This is more consistent with the other options and clearly scopes the option to this package.

See #125.

---

Also, rename option `update_snapshots` -> `playwright_visual_update_snapshots`

This does not affect the CLI usage, but ensures that it is consistently named if referenced within `pytest_configure`.