### PR TITLE
feat: add reset_scroll option to assert_snapshot (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ cp -R ${PLAYWRIGHT_RESULT_DIRECTORY}/${failed_run_id}/test-results/${PLAYWRIGHT_
 <!-- - `name` - `.png` extensions only. Default is `test_name[browser][os].png` (recommended) -->
 - `fail_fast` - If `True`, will fail after first different pixel. `False` by default
 - `mask_elements` - List of CSS selectors to mask during screenshot capture. These will be combined with any globally configured masks.
+- `reset_scroll` - If `True`, scrolls the page to `(0, 0)` before capturing a `Page` screenshot. Useful when prior test actions leave the viewport scrolled. Default is `False`.
+
+```python
+def test_homepage(page, assert_snapshot: AssertSnapshot):
+    page.goto("https://example.com")
+    page.evaluate("window.scrollTo(0, 500)")
+    assert_snapshot(page, reset_scroll=True)
+```
 
 ### Command Line Options
 

--- a/pytest_playwright_visual_snapshot/plugin.py
+++ b/pytest_playwright_visual_snapshot/plugin.py
@@ -333,6 +333,7 @@ class AssertSnapshot:
         name: str | None = None,
         fail_fast: bool = False,
         mask_elements: list[str] | None = None,
+        reset_scroll: bool = False,
     ) -> None:
         if self._disable_snapshots:
             if not self._warned_disabled:
@@ -379,6 +380,9 @@ class AssertSnapshot:
                 "mask": masks,
                 **self._screenshot_kwargs,
             }
+
+            if isinstance(img_or_page, SyncPage) and reset_scroll:
+                img_or_page.evaluate("window.scrollTo(0, 0)")
 
             img = img_or_page.screenshot(**screenshot_kwargs)
         else:

--- a/tests/test_reset_scroll.py
+++ b/tests/test_reset_scroll.py
@@ -1,0 +1,62 @@
+import pytest
+
+from tests.conftest import get_snapshots_dir
+
+_TALL_PAGE = (
+    "data:text/html,"
+    "<html><body style='margin:0'>"
+    "<div style='height:800px;background:red'></div>"
+    "<div style='height:800px;background:blue'></div>"
+    "</body></html>"
+)
+
+
+def test_reset_scroll_matches_top_of_page(testdir: pytest.Testdir) -> None:
+    """Scrolled page with reset_scroll=True matches an unscrolled baseline."""
+    testdir.makepyfile(
+        f"""
+        def test_snapshot(page, assert_snapshot):
+            page.goto("{_TALL_PAGE}")
+            page.evaluate("window.scrollTo(0, 800)")
+            assert_snapshot(page, reset_scroll=True)
+        """
+    )
+
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1, errors=1)
+    assert "[playwright-visual-snapshot] New snapshot(s) created" in "".join(
+        result.outlines
+    )
+
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1)
+
+
+def test_without_reset_scroll_differs_from_top(testdir: pytest.Testdir) -> None:
+    """Scrolled capture without reset_scroll differs from a top-of-page baseline."""
+    testdir.makepyfile(
+        f"""
+        def test_snapshot(page, assert_snapshot):
+            page.goto("{_TALL_PAGE}")
+            assert_snapshot(page)
+        """
+    )
+
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1, errors=1)
+    assert get_snapshots_dir(testdir).exists()
+
+    testdir.makepyfile(
+        f"""
+        def test_snapshot(page, assert_snapshot):
+            page.goto("{_TALL_PAGE}")
+            page.evaluate("window.scrollTo(0, 800)")
+            assert_snapshot(page)
+        """
+    )
+
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(failed=1)
+    assert "[playwright-visual-snapshot] Snapshot does not match" in "".join(
+        result.outlines
+    )

--- a/tests/test_reset_scroll.py
+++ b/tests/test_reset_scroll.py
@@ -56,7 +56,7 @@ def test_without_reset_scroll_differs_from_top(testdir: pytest.Testdir) -> None:
     )
 
     result = testdir.runpytest("--browser", "chromium")
-    result.assert_outcomes(failed=1)
-    assert "[playwright-visual-snapshot] Snapshot does not match" in "".join(
+    result.assert_outcomes(passed=1, errors=1)
+    assert "[playwright-visual-snapshot] Snapshots DO NOT match!" in "".join(
         result.outlines
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a per-call `reset_scroll` kwarg on `assert_snapshot` that runs `window.scrollTo(0, 0)` before capturing a `Page` screenshot. Default is `False`; no INI/CLI/global option.

Fixes #187.

## Usage

```python
assert_snapshot(page, reset_scroll=True)
```

Only applies when capturing from a `Page` (not `Locator` or raw bytes).

## Test plan

- [x] Unit/pytester coverage for reset vs no-reset scroll behavior
- [x] `pytest --ignore=tests/integration` — 28 passed, 5 skipped (odiff)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fed4562-0ab1-4087-bf3c-cdacfd72732c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fed4562-0ab1-4087-bf3c-cdacfd72732c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

